### PR TITLE
refactor: replace PATCH and action-POSTs with PUT sub-resources

### DIFF
--- a/quiz_core.py
+++ b/quiz_core.py
@@ -562,12 +562,12 @@ def _http_error_message(code: int, url: str) -> str:
     return f"HTTP {code} — {hint} [{url}]"
 
 
-def _post_json(url: str, payload: dict, username: str = "", password: str = "") -> dict:
+def _request_json(url: str, payload: dict, method: str = "POST", username: str = "", password: str = "") -> dict:
     data = json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if username:
         headers["Authorization"] = "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
-    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
         with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS, context=_ssl_context()) as resp:
             try:
@@ -582,6 +582,14 @@ def _post_json(url: str, payload: dict, username: str = "", password: str = "") 
         raise RuntimeError(f"Cannot reach server: {e.reason} [{url}]") from e
     except OSError as e:
         raise RuntimeError(f"Cannot reach server: {e} [{url}]") from e
+
+
+def _post_json(url: str, payload: dict, username: str = "", password: str = "") -> dict:
+    return _request_json(url, payload, method="POST", username=username, password=password)
+
+
+def _put_json(url: str, payload: dict, username: str = "", password: str = "") -> dict:
+    return _request_json(url, payload, method="PUT", username=username, password=password)
 
 
 def _get_json(url: str, username: str = "", password: str = "") -> dict:
@@ -618,7 +626,7 @@ def post_poll(quiz: dict, config: Config) -> None:
 
 
 def open_poll(config: Config) -> None:
-    _post_json(f"{config.server_url}/api/poll/status", {"open": True}, config.host_username, config.host_password)
+    _put_json(f"{config.server_url}/api/poll/status", {"open": True}, config.host_username, config.host_password)
 
 
 def post_status(status: str, message: str, config: Config,

--- a/routers/poll.py
+++ b/routers/poll.py
@@ -72,7 +72,7 @@ async def create_poll(poll: PollCreate):
     return {"ok": True, "poll": state.poll}
 
 
-@router.post("/api/poll/status", dependencies=[Depends(require_host_auth)])
+@router.put("/api/poll/status", dependencies=[Depends(require_host_auth)])
 async def set_poll_status(body: PollOpen):
     if not state.poll:
         raise HTTPException(400, "No poll created yet")
@@ -85,7 +85,7 @@ async def set_poll_status(body: PollOpen):
     return {"ok": True, "poll_active": state.poll_active}
 
 
-@router.post("/api/poll/correct", dependencies=[Depends(require_host_auth)])
+@router.put("/api/poll/correct", dependencies=[Depends(require_host_auth)])
 async def set_correct_options(body: PollCorrect):
     if not state.poll:
         raise HTTPException(400, "No active poll")

--- a/routers/qa.py
+++ b/routers/qa.py
@@ -18,7 +18,7 @@ class AnswerToggle(BaseModel):
     answered: bool
 
 
-@router.patch("/api/qa/question/{question_id}", dependencies=[Depends(require_host_auth)])
+@router.put("/api/qa/question/{question_id}/text", dependencies=[Depends(require_host_auth)])
 async def edit_question(question_id: str, body: QuestionEdit):
     q = state.qa_questions.get(question_id)
     if not q:
@@ -42,7 +42,7 @@ async def delete_question(question_id: str):
     return {"ok": True}
 
 
-@router.post("/api/qa/answer/{question_id}", dependencies=[Depends(require_host_auth)])
+@router.put("/api/qa/question/{question_id}/answered", dependencies=[Depends(require_host_auth)])
 async def toggle_answered(question_id: str, body: AnswerToggle):
     q = state.qa_questions.get(question_id)
     if not q:

--- a/static/host.js
+++ b/static/host.js
@@ -85,7 +85,7 @@
     recordPollInHistory(currentPoll, correctOptIds);
     // Post to backend to award points
     const resp = await fetch('/api/poll/correct', {
-      method: 'POST',
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ correct_ids: [...correctOptIds] }),
     });
@@ -528,7 +528,7 @@
   // ── Open / close / clear ──
   async function setPollStatus(open) {
     await fetch('/api/poll/status', {
-      method: 'POST',
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ open }),
     });
@@ -976,8 +976,8 @@
   }
 
   async function toggleAnswered(qid, current) {
-    await fetch(`/api/qa/answer/${qid}`, {
-      method: 'POST',
+    await fetch(`/api/qa/question/${qid}/answered`, {
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ answered: !current }),
     });
@@ -1011,8 +1011,8 @@
       const newText = input.value.trim();
       if (newText && newText !== currentText) {
         textEl.textContent = newText; // optimistic update (WS will confirm)
-        await fetch(`/api/qa/question/${qid}`, {
-          method: 'PATCH',
+        await fetch(`/api/qa/question/${qid}/text`, {
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text: newText }),
         });

--- a/static/version.js
+++ b/static/version.js
@@ -1,1 +1,1 @@
-window.APP_VERSION = '2026-03-20 10:28';
+window.APP_VERSION = '2026-03-20 10:36';

--- a/test_e2e.py
+++ b/test_e2e.py
@@ -735,7 +735,7 @@ class TestNotifications:
         (first state message seeds tracking state, doesn't trigger)."""
         _api(server_url, "post", "/api/poll",
              json={"question": "Notif test Q", "options": ["A", "B"]})
-        _api(server_url, "post", "/api/poll/status", json={"open": True})
+        _api(server_url, "put", "/api/poll/status", json={"open": True})
 
         try:
             browser = playwright.chromium.launch()
@@ -770,5 +770,5 @@ class TestNotifications:
             assert not notif_fired, "No notification should fire when joining mid-poll"
             browser.close()
         finally:
-            _api(server_url, "post", "/api/poll/status", json={"open": False})
+            _api(server_url, "put", "/api/poll/status", json={"open": False})
             _api(server_url, "delete", "/api/poll")

--- a/test_load.py
+++ b/test_load.py
@@ -194,7 +194,7 @@ def test_load(server_url):
         assert poll_resp.status_code == 200, f"create_poll failed: {poll_resp.text}"
         correct_id = poll_resp.json()["poll"]["options"][0]["id"]  # opt0 is the "correct" answer
 
-        await asyncio.to_thread(lambda: _host(server_url, "post", "/api/poll/status", json={"open": True}))
+        await asyncio.to_thread(lambda: _host(server_url, "put", "/api/poll/status", json={"open": True}))
         poll_ready_event.set()
         print(f"✓ Poll opened — {n} participants voting...")
 
@@ -212,8 +212,8 @@ def test_load(server_url):
         print(f"✓ All {n} votes cast")
 
         # Phase 4: close poll and post correct answer → triggers scores broadcast
-        await asyncio.to_thread(lambda: _host(server_url, "post", "/api/poll/status", json={"open": False}))
-        await asyncio.to_thread(lambda: _host(server_url, "post", "/api/poll/correct", json={"correct_ids": [correct_id]}))
+        await asyncio.to_thread(lambda: _host(server_url, "put", "/api/poll/status", json={"open": False}))
+        await asyncio.to_thread(lambda: _host(server_url, "put", "/api/poll/correct", json={"correct_ids": [correct_id]}))
         print("✓ Poll closed, correct answer posted")
 
         # Phase 5: wait for all scores received

--- a/test_main.py
+++ b/test_main.py
@@ -185,7 +185,7 @@ class WorkshopSession:
         assert self._poll, "No current poll"
         text_to_id = {o["text"]: o["id"] for o in self._poll["options"]}
         ids = [text_to_id[t] for t in option_texts]
-        resp = self._client.post("/api/poll/correct", json={"correct_ids": ids})
+        resp = self._client.put("/api/poll/correct", json={"correct_ids": ids})
         assert resp.status_code == 200, f"mark_correct failed: {resp.text}"
 
     def get_scores(self) -> dict:
@@ -201,12 +201,12 @@ class WorkshopSession:
         assert resp.status_code == 200
 
     def open_poll(self):
-        resp = self._client.post("/api/poll/status", json={"open": True})
+        resp = self._client.put("/api/poll/status", json={"open": True})
         assert resp.status_code == 200
         assert resp.json()["poll_active"] is True
 
     def close_poll(self):
-        resp = self._client.post("/api/poll/status", json={"open": False})
+        resp = self._client.put("/api/poll/status", json={"open": False})
         assert resp.status_code == 200
         assert resp.json()["poll_active"] is False
 
@@ -753,12 +753,12 @@ class TestQA:
 
     def test_edit_question_updates_text(self, session):
         qid = self._submit_ws(session, "Alice", "Original text")
-        resp = session._client.patch(f"/api/qa/question/{qid}", json={"text": "Edited text"})
+        resp = session._client.put(f"/api/qa/question/{qid}/text", json={"text": "Edited text"})
         assert resp.status_code == 200, resp.text
         assert state.qa_questions[qid]["text"] == "Edited text"
 
     def test_edit_question_not_found_returns_404(self, session):
-        resp = session._client.patch("/api/qa/question/nonexistent-id", json={"text": "New"})
+        resp = session._client.put("/api/qa/question/nonexistent-id/text", json={"text": "New"})
         assert resp.status_code == 404
 
     def test_delete_question_removes_from_state(self, session):


### PR DESCRIPTION
## Summary
- Replace `PATCH /api/qa/question/{id}` with `PUT /api/qa/question/{id}/text` (sub-resource for text editing)
- Replace `POST /api/qa/answer/{id}` with `PUT /api/qa/question/{id}/answered` (sub-resource for answered toggle)
- Replace `POST /api/poll/status` with `PUT /api/poll/status` (idempotent state update)
- Replace `POST /api/poll/correct` with `PUT /api/poll/correct` (idempotent state update)

## Test plan
- [x] 62 unit tests pass
- [x] 34 e2e tests pass (1 skipped)
- [ ] Manual smoke test on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)