### PR TITLE
feat: anchor summary bullets to transcript timestamps

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -148,6 +148,8 @@ Script which generates navigable HTML page from the catalog Google Doc as a prot
 ## Agree-Disagree Slider
 Host posts a provocative statement (e.g. "Microservices are always a mistake for teams under 20 people"). Participants drag a slider from Strongly Disagree to Strongly Agree. Host sees the full distribution as a histogram. Sliders capture *degree* of opinion — richer than binary polls for an audience that hates false dichotomies.
 
+- [x] GH#29: Summary bullets now include approximate timestamps (HH:MM) derived from transcript timing data, displayed as subtle prefixes in the UI
+
 ## Concept Ranking / Ordering
 Host presents 4–6 items (patterns, approaches, technologies). Participants drag them into an order (e.g. safest → most dangerous, simplest → most complex). Host aggregates the median ranking and highlights disagreements. Pure conceptual reasoning, no coding.
 

--- a/daemon/summarizer.py
+++ b/daemon/summarizer.py
@@ -43,9 +43,10 @@ Output rules:
 - For each bullet, indicate source:
   - "notes" if it comes primarily from SESSION NOTES (trainer's agenda/material)
   - "discussion" if it comes primarily from TRANSCRIPT (what was actually said)
+- For each bullet, include "time": the approximate timestamp (HH:MM format, 24h) when the topic was discussed, based on the transcript timestamps. Use the earliest relevant timestamp for the topic. Omit "time" for bullets derived solely from session notes with no transcript match.
 
 Return ONLY a JSON array of objects. No markdown, no explanation.
-Example: [{"text": "Outbox pattern decouples DB writes from message publishing", "source": "discussion"}, \
+Example: [{"text": "Outbox pattern decouples DB writes from message publishing", "source": "discussion", "time": "10:15"}, \
 {"text": "Hands-on: implement Circuit Breaker with Resilience4j", "source": "notes"}]
 """
 
@@ -126,7 +127,10 @@ def generate_summary(
                 source = item.get("source", "discussion")
                 if source not in ("notes", "discussion"):
                     source = "discussion"
-                points.append({"text": item["text"], "source": source})
+                point = {"text": item["text"], "source": source}
+                if item.get("time"):
+                    point["time"] = item["time"]
+                points.append(point)
             elif isinstance(item, str):
                 points.append({"text": item, "source": "discussion"})
             else:

--- a/routers/summary.py
+++ b/routers/summary.py
@@ -13,6 +13,7 @@ public_router = APIRouter()
 class SummaryPoint(BaseModel):
     text: str
     source: str = "discussion"  # "notes" or "discussion"
+    time: str | None = None  # approximate HH:MM timestamp from transcript
 
 
 class SummaryUpdate(BaseModel):

--- a/static/common.css
+++ b/static/common.css
@@ -178,6 +178,13 @@
   color: var(--text-muted);
   text-align: right;
 }
+.summary-ts {
+  font-size: .7rem;
+  color: var(--accent);
+  opacity: .7;
+  font-family: monospace;
+  margin-right: .3em;
+}
 .header-link-btn {
   background: none;
   border: 1px solid var(--border);

--- a/static/host.js
+++ b/static/host.js
@@ -268,7 +268,8 @@
       const text = typeof p === 'string' ? p : p.text;
       const source = typeof p === 'string' ? 'discussion' : (p.source || 'discussion');
       const icon = source === 'notes' ? '✏️' : '💬';
-      return `<li>${icon} ${escHtml(text)}</li>`;
+      const time = (typeof p === 'object' && p.time) ? `<span class="summary-ts">${escHtml(p.time)}</span>` : '';
+      return `<li>${icon} ${time}${escHtml(text)}</li>`;
     }).join('');
     if (timeEl && summaryUpdatedAt) {
       const d = new Date(summaryUpdatedAt);

--- a/static/notes.html
+++ b/static/notes.html
@@ -76,7 +76,8 @@
             const text = typeof p === 'string' ? p : p.text;
             const source = typeof p === 'string' ? 'discussion' : (p.source || 'discussion');
             const icon = source === 'notes' ? '&#9999;&#65039;' : '&#128172;';
-            return `<li>${icon} ${linkify(escHtml(text))}</li>`;
+            const time = (typeof p === 'object' && p.time) ? `<span class="summary-ts">${escHtml(p.time)}</span>` : '';
+            return `<li>${icon} ${time}${linkify(escHtml(text))}</li>`;
           }).join('');
         } else {
           pointsEl.innerHTML = '<li class="empty">No key points yet.</li>';

--- a/static/participant.js
+++ b/static/participant.js
@@ -116,7 +116,8 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
       const text = typeof p === 'string' ? p : p.text;
       const source = typeof p === 'string' ? 'discussion' : (p.source || 'discussion');
       const icon = source === 'notes' ? '✏️' : '💬';
-      return `<li>${icon} ${escHtml(text)}</li>`;
+      const time = (typeof p === 'object' && p.time) ? `<span class="summary-ts">${escHtml(p.time)}</span>` : '';
+      return `<li>${icon} ${time}${escHtml(text)}</li>`;
     }).join('');
     if (timeEl && summaryUpdatedAt) {
       const d = new Date(summaryUpdatedAt);
@@ -128,7 +129,8 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
     if (!summaryPoints.length) return;
     const lines = summaryPoints.map(p => {
       const text = typeof p === 'string' ? p : p.text;
-      return '• ' + text;
+      const time = (typeof p === 'object' && p.time) ? `[${p.time}] ` : '';
+      return '• ' + time + text;
     });
     const content = 'Key Points\n' + '='.repeat(10) + '\n\n' + lines.join('\n');
     const blob = new Blob([content], { type: 'text/plain' });

--- a/static/version.js
+++ b/static/version.js
@@ -1,1 +1,1 @@
-window.APP_VERSION = '2026-03-20 19:20';
+window.APP_VERSION = '2026-03-20 19:28';

--- a/test_main.py
+++ b/test_main.py
@@ -952,6 +952,24 @@ def test_post_summary_updates_state():
         assert alice._last_state["summary_points"][1]["source"] == "notes"
 
 
+def test_post_summary_with_timestamps():
+    """POST /api/summary with time fields stores and broadcasts them."""
+    session = WorkshopSession()
+    resp = session._client.post(
+        "/api/summary",
+        json={"points": [
+            {"text": "TDD basics", "source": "discussion", "time": "10:15"},
+            {"text": "Mocking patterns", "source": "notes"},
+        ]},
+    )
+    assert resp.status_code == 200
+
+    with session.participant("Alice") as alice:
+        pts = alice._last_state["summary_points"]
+        assert pts[0]["time"] == "10:15"
+        assert pts[1].get("time") is None
+
+
 def test_post_summary_requires_auth():
     """POST /api/summary without auth returns 401."""
     client = TestClient(app)  # no auth headers


### PR DESCRIPTION
## Summary
- Each summary bullet now includes an approximate HH:MM timestamp derived from transcript timing data
- LLM prompt updated to extract timestamps; `SummaryPoint` model extended with optional `time` field
- UI displays timestamps as subtle monospace prefixes in host, participant, and notes views
- Fully backward-compatible: bullets without timestamps render identically to before

## Test plan
- [x] All 86 existing tests pass
- [x] New test `test_post_summary_with_timestamps` verifies time field storage and broadcast
- [ ] Manual: verify timestamp rendering in participant and host summary modals with live daemon

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)