### PR TITLE
fix: restore participant vote and poll results on refresh (#33)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -126,6 +126,7 @@
 - [x] Bug! If there is no vote for any participants and I close the voting, each option gets 1% displayed in the participant view, which makes no sense. It should be 0% for all.
 - [x] feat: browser push notifications — participant UI requests permission on Join; 🔔 button for auto-joiners; notifies on new poll/Q&A/word cloud when tab is hidden
 - [x] feat: Code Review activity — host pastes a code snippet (with auto-detected language and syntax highlighting), participants click line numbers to flag problematic lines, host sees live heat-map of selections, confirms correct lines one by one to award points and spark discussion; phase transitions: idle → selecting → reviewing
+- [x] fix: participant vote and poll results lost on browser refresh — server now sends `my_vote` and `poll_correct_ids`/`my_voted_ids` in state broadcasts so vote + correct/incorrect feedback survive reconnect (GH #33)
 ---
 
 ## Understanding design

--- a/messaging.py
+++ b/messaging.py
@@ -18,6 +18,17 @@ def participant_ids() -> list[str]:
     )
 
 
+def _voted_ids_for(pid: str) -> list[str] | None:
+    """Return the participant's voted option IDs as a list, or None if not voted."""
+    if state.poll_correct_ids is None:
+        return None
+    selection = state.votes.get(pid)
+    if selection is None:
+        return None
+    ids = selection if isinstance(selection, list) else [selection]
+    return list(ids)
+
+
 def _build_qa_for_participant(pid: str) -> list[dict]:
     return [
         {
@@ -187,6 +198,9 @@ def build_participant_state(pid: str) -> dict:
         "vote_counts": state.vote_counts(),
         "participant_count": len(pids),
         "host_connected": "__host__" in state.participants,
+        "my_vote": state.votes.get(pid),
+        "poll_correct_ids": state.poll_correct_ids,
+        "my_voted_ids": _voted_ids_for(pid),
         "my_score": state.scores.get(pid, 0),
         "my_avatar": state.participant_avatars.get(pid, ""),
         "current_activity": state.current_activity,

--- a/routers/poll.py
+++ b/routers/poll.py
@@ -67,6 +67,7 @@ async def create_poll(poll: PollCreate):
     state.current_activity = ActivityType.POLL
     state.poll_active = False
     state.votes = {}
+    state.poll_correct_ids = None
 
     await broadcast_state()
     return {"ok": True, "poll": state.poll}
@@ -147,6 +148,7 @@ async def set_correct_options(body: PollCorrect):
             new_scores[pid] = new_scores.get(pid, 0) + pts
 
     state.scores = new_scores
+    state.poll_correct_ids = list(correct_set)
     await broadcast_state()
 
     for pid, ws in list(state.participants.items()):
@@ -183,6 +185,7 @@ async def clear_poll():
     state.poll = None
     state.poll_active = False
     state.votes = {}
+    state.poll_correct_ids = None
     state.base_scores = dict(state.scores)
     state.vote_times = {}
     state.current_activity = ActivityType.NONE

--- a/state.py
+++ b/state.py
@@ -50,6 +50,7 @@ class AppState:
         self.scores: dict[str, int] = {}
         self.base_scores: dict[str, int] = {}
         self.poll_opened_at: Optional[datetime] = None
+        self.poll_correct_ids: Optional[list[str]] = None
         self.vote_times: dict[str, datetime] = {}
         self.current_activity: ActivityType = ActivityType.NONE
         self.wordcloud_words: dict[str, int] = {}

--- a/static/participant.js
+++ b/static/participant.js
@@ -410,7 +410,16 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
           _multiWarnShown = false;
           focusedOptionIndex = -1;
           clearInterval(_timerInterval);
+        }
+        // Restore vote from server state (authoritative), falling back to localStorage
+        if (msg.my_vote != null) {
+          myVote = msg.poll?.multi ? new Set(msg.my_vote) : msg.my_vote;
+        } else if (msg.poll?.id !== currentPoll?.id) {
           restoreVote(msg.poll);
+        }
+        // Restore poll result from server state (survives refresh)
+        if (msg.poll_correct_ids != null && msg.my_voted_ids != null) {
+          pollResult = { correct_ids: new Set(msg.poll_correct_ids), voted_ids: new Set(msg.my_voted_ids) };
         }
         currentPoll = msg.poll;
         pollActive = msg.poll_active;

--- a/static/version.js
+++ b/static/version.js
@@ -1,1 +1,1 @@
-window.APP_VERSION = '2026-03-20 19:28';
+window.APP_VERSION = '2026-03-20 19:32';

--- a/test_main.py
+++ b/test_main.py
@@ -143,6 +143,42 @@ class ParticipantSession:
             f"{self.name}: expected no score but got {state.scores.get(self.uuid)}"
         )
 
+    def assert_my_vote(self, expected_option_text: str):
+        """Assert that my_vote in state matches an option by text."""
+        my_vote = self._last_state.get("my_vote")
+        poll = self._last_state.get("poll") or state.poll
+        text_to_id = {o["text"]: o["id"] for o in poll["options"]}
+        expected_id = text_to_id[expected_option_text]
+        assert my_vote == expected_id, (
+            f"{self.name}: my_vote={my_vote!r}, expected {expected_id!r} ({expected_option_text!r})"
+        )
+
+    def assert_no_my_vote(self):
+        """Assert that my_vote is None (not voted)."""
+        my_vote = self._last_state.get("my_vote")
+        assert my_vote is None, f"{self.name}: expected my_vote=None, got {my_vote!r}"
+
+    def assert_result_in_state(self, correct_texts: list[str], voted_texts: list[str]):
+        """Assert that poll result (correct_ids, voted_ids) is in the state broadcast."""
+        poll = self._last_state.get("poll") or state.poll
+        text_to_id = {o["text"]: o["id"] for o in poll["options"]}
+        expected_correct = set(text_to_id[t] for t in correct_texts)
+        expected_voted = set(text_to_id[t] for t in voted_texts)
+        actual_correct = set(self._last_state.get("poll_correct_ids") or [])
+        actual_voted = set(self._last_state.get("my_voted_ids") or [])
+        assert actual_correct == expected_correct, (
+            f"{self.name}: poll_correct_ids={actual_correct}, expected {expected_correct}"
+        )
+        assert actual_voted == expected_voted, (
+            f"{self.name}: my_voted_ids={actual_voted}, expected {expected_voted}"
+        )
+
+    def assert_no_result_in_state(self):
+        """Assert no poll result in state."""
+        assert self._last_state.get("poll_correct_ids") is None, (
+            f"{self.name}: expected no poll_correct_ids, got {self._last_state.get('poll_correct_ids')}"
+        )
+
     def assert_wordcloud_word(self, word: str, expected_count: int):
         """Assert a word's count in the word cloud state."""
         words = self._last_state.get("wordcloud_words", {})
@@ -242,6 +278,12 @@ class WorkshopSession:
     @contextmanager
     def participant(self, name: str):
         uid = str(uuid_mod.uuid4())
+        with self._client.websocket_connect(f"/ws/{uid}") as ws:
+            yield ParticipantSession(ws, name, uid)
+
+    @contextmanager
+    def participant_with_uuid(self, name: str, uid: str):
+        """Connect a participant with a specific UUID (for reconnect tests)."""
         with self._client.websocket_connect(f"/ws/{uid}") as ws:
             yield ParticipantSession(ws, name, uid)
 
@@ -1045,3 +1087,76 @@ def test_auto_assign_remaining(total, pre_assigned, expect_trigger, expect_balan
     assert abs(for_count - against_count) <= 1, (
         f"Unbalanced: {for_count} for vs {against_count} against"
     )
+
+
+# ---------------------------------------------------------------------------
+# Vote & Result Restore on Refresh (GH #33)
+# ---------------------------------------------------------------------------
+
+class TestVoteRestoreOnRefresh:
+    """Verify that my_vote and poll results survive participant reconnect."""
+
+    def test_my_vote_included_in_state_after_voting(self, session):
+        """After voting, participant state should include my_vote."""
+        session.create_poll("Pick one", ["A", "B"])
+        session.open_poll()
+        uid = str(uuid_mod.uuid4())
+        with session.participant_with_uuid("Alice", uid) as alice:
+            alice.vote_for("A")
+            # Reconnect — simulates browser refresh
+        with session.participant_with_uuid("Alice", uid) as alice2:
+            alice2.assert_my_vote("A")
+
+    def test_my_vote_none_when_not_voted(self, session):
+        """Participant who hasn't voted should get my_vote=None."""
+        session.create_poll("Pick one", ["A", "B"])
+        session.open_poll()
+        with session.participant("Alice") as alice:
+            alice.assert_no_my_vote()
+
+    def test_my_vote_multi_included_in_state(self, session):
+        """Multi-select vote should be restored on reconnect."""
+        session.create_poll("Pick many", ["A", "B", "C"], multi=True)
+        session.open_poll()
+        uid = str(uuid_mod.uuid4())
+        with session.participant_with_uuid("Alice", uid) as alice:
+            alice.multi_vote("A", "C")
+        with session.participant_with_uuid("Alice", uid) as alice2:
+            my_vote = alice2._last_state.get("my_vote")
+            assert set(my_vote) == {"opt0", "opt2"}, f"my_vote={my_vote}"
+
+    def test_poll_result_included_in_state_after_correct_marked(self, session):
+        """After host marks correct, reconnecting participant sees result in state."""
+        session.create_poll("Q?", ["A", "B"])
+        session.open_poll()
+        uid = str(uuid_mod.uuid4())
+        with session.participant_with_uuid("Alice", uid) as alice:
+            alice.vote_for("A")
+        session.close_poll()
+        session.mark_correct("A")
+        # Reconnect
+        with session.participant_with_uuid("Alice", uid) as alice2:
+            alice2.assert_result_in_state(correct_texts=["A"], voted_texts=["A"])
+
+    def test_no_result_before_correct_marked(self, session):
+        """Before host marks correct, no result in state."""
+        session.create_poll("Q?", ["A", "B"])
+        session.open_poll()
+        with session.participant("Alice") as alice:
+            alice.vote_for("A")
+            alice.assert_no_result_in_state()
+
+    def test_result_cleared_on_new_poll(self, session):
+        """Creating a new poll should clear previous result."""
+        session.create_poll("Q1", ["A", "B"])
+        session.open_poll()
+        uid = str(uuid_mod.uuid4())
+        with session.participant_with_uuid("Alice", uid) as alice:
+            alice.vote_for("A")
+        session.close_poll()
+        session.mark_correct("A")
+        # New poll
+        session.create_poll("Q2", ["X", "Y"])
+        with session.participant_with_uuid("Alice", uid) as alice2:
+            alice2.assert_no_result_in_state()
+            alice2.assert_no_my_vote()


### PR DESCRIPTION
## Summary
- Server now includes `my_vote`, `poll_correct_ids`, and `my_voted_ids` in participant state broadcasts so vote selection and correct/incorrect feedback survive browser refresh
- Client prefers server-sent vote over localStorage fallback, and restores poll result coloring from state
- `poll_correct_ids` is stored in `AppState`, set when host marks correct answers, cleared on new poll or poll deletion
- 6 new integration tests covering vote restore, multi-vote restore, result restore, and cleanup on new poll

## Test plan
- [x] 91/91 tests pass (0 regressions)
- [x] Manual browser test: vote persists after refresh
- [x] Manual browser test: correct/incorrect result coloring persists after refresh

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)