### PR TITLE
refactor: move debate AI cleanup from backend to local daemon

### DIFF
--- a/adoc/c4_c2_containers.puml
+++ b/adoc/c4_c2_containers.puml
@@ -15,17 +15,17 @@ System_Boundary(workshop, "Workshop Tool", $link="c4_c3_components.puml") {
 
     Container(caddy, "Caddy Reverse Proxy", "Caddy (single binary)", "TLS termination.\nAuth for host endpoints.\nForwards to FastAPI on :8000.")
 
-    Container(fastapi, "FastAPI Backend", "Python 3.9 / FastAPI / Uvicorn", "REST endpoints + WebSocket.\nRuns as systemd service on Oracle Cloud.", $link="c4_c3_components.puml")
+    Container(fastapi, "FastAPI Backend", "Python 3.12 / FastAPI / Uvicorn", "REST endpoints + WebSocket.\nDeployed on Railway.", $link="c4_c3_components.puml")
 
     Container(host_spa, "Host SPA", "Vanilla JS (host's browser)", "Poll management, participant list,\nmap view (Leaflet), quiz preview.")
 
-    Container(quiz_daemon, "Quiz Daemon", "Python 3.12 CLI (host's machine)", "Long-polls backend for quiz requests.\nPosts AI-generated preview to backend.\nPeriodically synthesizes session key points.")
+    Container(quiz_daemon, "Quiz Daemon", "Python 3.12 CLI (host's machine)", "Long-polls backend for quiz requests\nand debate AI cleanup.\nPosts AI-generated content to backend.\nPeriodically synthesizes session key points.")
 }
 
 ' ── right: host + external AI ────────────────────────────────────
 Person(host, "Host", "Workshop facilitator.")
 System_Ext(audio_hijack, "Audio Hijack", "Captures live audio and writes\nthe transcript file.")
-System_Ext(claude_api, "Anthropic Claude API", "LLM for quiz generation.")
+System_Ext(claude_api, "Anthropic Claude API", "LLM for quiz generation,\ndebate argument cleanup,\nand session summaries.")
 System_Ext(nominatim, "Nominatim", "GPS coords → city + country.")
 
 ' layout hints — keep host cluster top-right, nominatim bottom-right
@@ -46,6 +46,6 @@ Rel(host_spa, nominatim, "Resolves GPS to city and map coordinates", "HTTPS REST
 Rel(host, quiz_daemon, "Starts/stops", "Local terminal")
 Rel(audio_hijack, quiz_daemon, "Transcript file", "Local file")
 Rel(quiz_daemon, caddy, "Polls for requests, posts preview", "HTTPS REST")
-Rel(quiz_daemon, claude_api, "Generates quiz + summary from transcript", "HTTPS REST")
+Rel(quiz_daemon, claude_api, "Generates quiz, debate AI cleanup, summary", "HTTPS REST")
 
 @enduml

--- a/daemon/debate_ai.py
+++ b/daemon/debate_ai.py
@@ -1,0 +1,56 @@
+"""Debate AI cleanup — called by the daemon when backend requests it."""
+import json
+
+import anthropic
+
+
+def run_debate_ai_cleanup(request: dict, api_key: str, model: str) -> dict:
+    """Call Claude to clean up debate arguments. Returns JSON result dict.
+
+    Args:
+        request: {"statement": str, "for_args": [...], "against_args": [...]}
+        api_key: Anthropic API key
+        model: Claude model to use
+
+    Returns:
+        {"merges": [...], "cleaned": [...], "new_arguments": [...]}
+    """
+    statement = request["statement"]
+    for_args = request["for_args"]
+    against_args = request["against_args"]
+
+    prompt = f"""You are helping clean up debate arguments about: "{statement}"
+
+FOR arguments:
+{chr(10).join(f'- [{a["id"]}] {a["text"]}' for a in for_args)}
+
+AGAINST arguments:
+{chr(10).join(f'- [{a["id"]}] {a["text"]}' for a in against_args)}
+
+Tasks:
+1. Identify duplicates — return which argument IDs should be merged (keep the better-worded one)
+2. For each surviving argument, return a cleaned version (fix typos, make concise, preserve intent)
+3. Add 2-4 NEW arguments that participants missed (mark side as "for" or "against")
+
+Return JSON (no markdown fences):
+{{
+  "merges": [{{"keep_id": "...", "remove_ids": ["..."]}}],
+  "cleaned": [{{"id": "...", "text": "cleaned text"}}],
+  "new_arguments": [{{"side": "for"|"against", "text": "..."}}]
+}}"""
+
+    client = anthropic.Anthropic(api_key=api_key)
+    response = client.messages.create(
+        model=model,
+        max_tokens=2048,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    raw_text = response.content[0].text.strip()
+    # Strip markdown fences if Claude wrapped the JSON
+    if raw_text.startswith("```"):
+        raw_text = raw_text.split("\n", 1)[1]
+        if raw_text.endswith("```"):
+            raw_text = raw_text[: -len("```")].rstrip()
+
+    return json.loads(raw_text)

--- a/quiz_daemon.py
+++ b/quiz_daemon.py
@@ -33,6 +33,7 @@ from quiz_core import (
     post_status, _get_json, _post_json, DAEMON_POLL_INTERVAL, DEFAULT_TRANSCRIPT_MINUTES,
     read_session_notes, load_transcription_files, extract_last_n_minutes,
 )
+from daemon.debate_ai import run_debate_ai_cleanup
 from daemon.summarizer import generate_summary, SUMMARY_INTERVAL_SECONDS
 
 _LOCK_FILE = Path("/tmp/quiz_daemon.lock")
@@ -363,6 +364,36 @@ def run() -> None:
                         last_quiz = updated
                 else:
                     post_status("error", "No conversation context — please generate a question first.", config)
+
+            # ── Check for debate AI cleanup request ──
+            try:
+                debate_data = _get_json(
+                    f"{config.server_url}/api/debate/ai-request",
+                    config.host_username, config.host_password,
+                )
+                debate_req = debate_data.get("request")
+                if debate_req:
+                    print(f"\n[daemon] Debate AI cleanup requested: '{debate_req['statement'][:60]}'")
+                    try:
+                        result = run_debate_ai_cleanup(debate_req, config.api_key, config.model)
+                        _post_json(
+                            f"{config.server_url}/api/debate/ai-result",
+                            result,
+                            config.host_username, config.host_password,
+                        )
+                        n_new = len(result.get("new_arguments", []))
+                        n_merges = len(result.get("merges", []))
+                        print(f"[daemon] Debate AI done: {n_merges} merges, {n_new} new args")
+                    except Exception as e:
+                        print(f"[daemon] Debate AI cleanup failed: {e}", file=sys.stderr)
+                        # Post empty result so backend advances to prep anyway
+                        _post_json(
+                            f"{config.server_url}/api/debate/ai-result",
+                            {"merges": [], "cleaned": [], "new_arguments": []},
+                            config.host_username, config.host_password,
+                        )
+            except RuntimeError:
+                pass  # server unreachable — skip this cycle
 
             # ── Push transcript stats every 10s ──
             if now - last_transcript_stats_at >= 10.0:

--- a/routers/debate.py
+++ b/routers/debate.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import random
 import uuid as uuid_mod
@@ -163,7 +162,7 @@ async def force_assign():
     return {"ok": True, "assigned": len(unassigned)}
 
 
-VALID_PHASES = {"arguments", "ai_cleanup", "prep", "live_debate"}
+VALID_PHASES = {"arguments", "ai_cleanup", "prep", "live_debate", "ended"}
 
 
 @router.post("/api/debate/phase", dependencies=[Depends(require_host_auth)])
@@ -251,98 +250,73 @@ async def end_sub_phase():
 
 @router.post("/api/debate/end-arguments", dependencies=[Depends(require_host_auth)])
 async def end_arguments():
-    """End arguments phase, run AI cleanup, then advance to prep."""
+    """End arguments phase — store AI request for daemon pickup."""
     if state.debate_phase != "arguments":
         raise HTTPException(400, "Not in arguments phase")
 
-    # Transition to ai_cleanup (visible to participants as "AI is reviewing…")
+    # Build the payload the daemon will consume
+    for_args = [{"id": a["id"], "text": a["text"]} for a in state.debate_arguments
+                if a["side"] == "for" and not a.get("merged_into")]
+    against_args = [{"id": a["id"], "text": a["text"]} for a in state.debate_arguments
+                    if a["side"] == "against" and not a.get("merged_into")]
+
+    if not for_args and not against_args:
+        # No arguments submitted — skip AI cleanup, go straight to prep
+        state.debate_phase = "prep"
+        logger.info("Arguments ended (none submitted) — skipping AI, advancing to prep")
+        await broadcast_state()
+        return {"ok": True}
+
+    state.debate_ai_request = {
+        "statement": state.debate_statement,
+        "for_args": for_args,
+        "against_args": against_args,
+    }
     state.debate_phase = "ai_cleanup"
-    logger.info("Arguments ended — running AI cleanup")
-    await broadcast_state()
-
-    # Run AI cleanup
-    try:
-        await _run_ai_cleanup()
-    except Exception as e:
-        logger.error(f"AI cleanup failed: {e}")
-        # Still advance to prep even if AI fails
-
-    # Advance to prep
-    state.debate_phase = "prep"
-    logger.info("AI cleanup done — advancing to prep")
+    logger.info("Arguments ended — waiting for daemon AI cleanup")
     await broadcast_state()
     return {"ok": True}
 
 
-async def _run_ai_cleanup():
-    """Run AI cleanup on debate arguments. Raises on failure."""
-    import os
-    from anthropic import Anthropic
+@router.get("/api/debate/ai-request", dependencies=[Depends(require_host_auth)])
+async def poll_debate_ai_request():
+    """Daemon polls this. Returns pending AI request or null, then clears it."""
+    req = state.debate_ai_request
+    state.debate_ai_request = None
+    return {"request": req}
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise RuntimeError("ANTHROPIC_API_KEY not set")
 
-    # Build prompt
-    for_args = [a for a in state.debate_arguments if a["side"] == "for" and not a.get("merged_into")]
-    against_args = [a for a in state.debate_arguments if a["side"] == "against" and not a.get("merged_into")]
+class DebateAiResult(BaseModel):
+    merges: list[dict] = []
+    cleaned: list[dict] = []
+    new_arguments: list[dict] = []
 
-    has_args = for_args or against_args
-    for_list = chr(10).join(f'- [{a["id"]}] {a["text"]}' for a in for_args) if for_args else "(none submitted)"
-    against_list = chr(10).join(f'- [{a["id"]}] {a["text"]}' for a in against_args) if against_args else "(none submitted)"
 
-    prompt = f"""You are helping clean up debate arguments about: "{state.debate_statement}"
-
-FOR arguments:
-{for_list}
-
-AGAINST arguments:
-{against_list}
-
-Tasks:
-1. Identify duplicates — return which argument IDs should be merged (keep the better-worded one)
-2. For each surviving argument, return a cleaned version (fix typos, make concise, preserve intent)
-3. Add 3-5 NEW arguments that participants missed (mark side as "for" or "against"), ensuring both sides are well represented{'' if has_args else ' — since no arguments were submitted, generate a balanced set of strong arguments for both sides'}
-
-Return JSON (no markdown fences):
-{{
-  "merges": [{{"keep_id": "...", "remove_ids": ["..."]}}],
-  "cleaned": [{{"id": "...", "text": "cleaned text"}}],
-  "new_arguments": [{{"side": "for"|"against", "text": "..."}}]
-}}"""
-
-    client = Anthropic(api_key=api_key)
-    response = client.messages.create(
-        model="claude-sonnet-4-20250514",
-        max_tokens=2048,
-        messages=[{"role": "user", "content": prompt}],
-    )
-
-    try:
-        result = json.loads(response.content[0].text)
-    except (json.JSONDecodeError, IndexError):
-        raise HTTPException(500, "AI returned invalid JSON")
+@router.post("/api/debate/ai-result", dependencies=[Depends(require_host_auth)])
+async def receive_ai_result(body: DebateAiResult):
+    """Daemon posts AI cleanup results. Apply and advance to prep."""
+    if state.debate_phase != "ai_cleanup":
+        raise HTTPException(400, "Not in ai_cleanup phase")
 
     # Apply merges
-    for merge in result.get("merges", []):
-        keep_id = merge["keep_id"]
+    for merge in body.merges:
+        keep_id = merge.get("keep_id")
         for remove_id in merge.get("remove_ids", []):
             for arg in state.debate_arguments:
                 if arg["id"] == remove_id:
                     arg["merged_into"] = keep_id
-                    # Transfer upvotes to kept argument
                     kept = next((a for a in state.debate_arguments if a["id"] == keep_id), None)
                     if kept:
                         kept["upvoters"] = kept["upvoters"] | arg["upvoters"]
 
     # Apply cleaned text
-    for cleaned in result.get("cleaned", []):
+    for cleaned in body.cleaned:
         for arg in state.debate_arguments:
-            if arg["id"] == cleaned["id"]:
+            if arg["id"] == cleaned.get("id"):
                 arg["text"] = cleaned["text"]
 
     # Add new AI arguments
-    for new_arg in result.get("new_arguments", []):
+    for new_arg in body.new_arguments:
         state.debate_arguments.append({
             "id": str(uuid_mod.uuid4()),
             "author_uuid": "__ai__",
@@ -353,14 +327,8 @@ Return JSON (no markdown fences):
             "merged_into": None,
         })
 
-    logger.info(f"AI cleanup done: {len(result.get('merges', []))} merges, {len(result.get('new_arguments', []))} new args")
+    logger.info(f"AI result received: {len(body.merges)} merges, {len(body.new_arguments)} new args")
 
-
-@router.post("/api/debate/ai-cleanup", dependencies=[Depends(require_host_auth)])
-async def ai_cleanup():
-    """Legacy endpoint — runs AI cleanup standalone."""
-    if state.debate_phase != "ai_cleanup":
-        raise HTTPException(400, "Not in ai_cleanup phase")
-    await _run_ai_cleanup()
+    state.debate_phase = "prep"
     await broadcast_state()
     return {"ok": True}

--- a/state.py
+++ b/state.py
@@ -78,6 +78,7 @@ class AppState:
         self.debate_sub_phase_index: Optional[int] = None  # 0-3 index, None = not started
         self.debate_sub_timer_seconds: Optional[int] = None
         self.debate_sub_timer_started_at: Optional[datetime] = None
+        self.debate_ai_request: Optional[dict] = None  # pending AI cleanup payload for daemon
 
     def suggest_name(self) -> str:
         """Return the next available LOTR name (by popularity order).

--- a/static/common.css
+++ b/static/common.css
@@ -421,3 +421,21 @@
   font-size: .85rem;
   color: var(--muted);
 }
+.debate-ai-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .75rem;
+  padding: 2rem;
+  color: var(--accent);
+  font-size: 1rem;
+}
+.debate-ai-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--surface2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: debate-spin 0.8s linear infinite;
+}
+@keyframes debate-spin { to { transform: rotate(360deg); } }

--- a/static/host.js
+++ b/static/host.js
@@ -1603,14 +1603,13 @@
     });
   }
 
-  async function debateRunAI() {
-    const btn = document.querySelector('#debate-host-actions .btn-ai');
-    if (btn) { btn.disabled = true; btn.textContent = '⏳ Running AI…'; }
-    try {
-      await fetch('/api/debate/ai-cleanup', { method: 'POST' });
-    } finally {
-      if (btn) { btn.disabled = false; btn.textContent = '✨ Run AI Cleanup'; }
-    }
+  async function debateSkipAI() {
+    // Post empty result to advance past ai_cleanup if daemon is unavailable
+    await fetch('/api/debate/ai-result', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ merges: [], cleaned: [], new_arguments: [] }),
+    });
   }
 
   function renderDebateHost(msg) {
@@ -1684,7 +1683,7 @@
 
       let actionHtml = '';
       if (isActive && phase === 'ai_cleanup' && p.key === 'prep') {
-        actionHtml = `<div class="debate-chapter-extra"><span style="color:var(--accent);font-size:.8rem;">✨ AI enriching arguments…</span></div>`;
+        actionHtml = `<div class="debate-chapter-extra"><span style="color:var(--accent);font-size:.8rem;">✨ AI enriching arguments…</span> <button class="btn btn-sm" onclick="debateSkipAI()" style="margin-left:.5rem;font-size:.7rem;">Skip AI</button></div>`;
       } else if (isActive && phaseActions[p.key]) {
         actionHtml = `<div class="debate-chapter-extra">${phaseActions[p.key]}</div>`;
       }
@@ -1807,6 +1806,12 @@
 
       // Restart countdown rendering if timer is active
       if (phase === 'live_debate' && _debateSubTimer) _startDebateCountdown();
+      if (phase === 'ai_cleanup') {
+        content.innerHTML += `<div class="debate-ai-loading">
+          <div class="debate-ai-spinner"></div>
+          <div>AI is enriching arguments…</div>
+        </div>`;
+      }
     }
   }
 

--- a/static/participant.js
+++ b/static/participant.js
@@ -1081,6 +1081,12 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
       }
     } else if (phase === 'prep') {
       html += renderDebateArgColumns(args, mySide, msg, false);
+      if (phase === 'ai_cleanup') {
+        html += `<div class="debate-ai-loading">
+          <div class="debate-ai-spinner"></div>
+          <div>AI is enriching arguments…</div>
+        </div>`;
+      }
       html += renderDebateHints();
       if (mySide && !champions[mySide]) {
         html += `<button class="btn btn-warn debate-volunteer-btn" onclick="debateVolunteer()">🏆 I'll be our champion!</button>`;

--- a/test_main.py
+++ b/test_main.py
@@ -1193,3 +1193,91 @@ class TestVoteRestoreOnRefresh:
         with session.participant_with_uuid("Alice", uid) as alice2:
             alice2.assert_no_result_in_state()
             alice2.assert_no_my_vote()
+
+
+# ---------------------------------------------------------------------------
+# Debate AI poll/result endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def test_debate_ai_request_returns_and_clears():
+    """GET /api/debate/ai-request returns pending request then clears it."""
+    state.reset()
+    client = TestClient(app)
+
+    # Setup: launch debate, add argument, end arguments
+    client.post("/api/debate", json={"statement": "Tabs vs spaces"}, headers=_HOST_AUTH_HEADERS)
+    state.debate_phase = "arguments"
+    state.debate_arguments = [{
+        "id": "a1", "author_uuid": "u1", "side": "for",
+        "text": "Tabs are better", "upvoters": set(),
+        "ai_generated": False, "merged_into": None,
+    }]
+    client.post("/api/debate/end-arguments", headers=_HOST_AUTH_HEADERS)
+
+    # First poll: should return the request
+    resp = client.get("/api/debate/ai-request", headers=_HOST_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["request"] is not None
+    assert data["request"]["statement"] == "Tabs vs spaces"
+    assert len(data["request"]["for_args"]) == 1
+
+    # Second poll: consumed (None)
+    resp2 = client.get("/api/debate/ai-request", headers=_HOST_AUTH_HEADERS)
+    assert resp2.json()["request"] is None
+
+
+def test_debate_ai_result_applies_and_advances():
+    """POST /api/debate/ai-result applies merges/new args, advances to prep."""
+    state.reset()
+    client = TestClient(app)
+    state.debate_statement = "Tabs vs spaces"
+    state.debate_phase = "ai_cleanup"
+    state.debate_arguments = [
+        {"id": "a1", "author_uuid": "u1", "side": "for",
+         "text": "Tabs are beter", "upvoters": set(),
+         "ai_generated": False, "merged_into": None},
+    ]
+
+    resp = client.post("/api/debate/ai-result", json={
+        "merges": [],
+        "cleaned": [{"id": "a1", "text": "Tabs are better"}],
+        "new_arguments": [
+            {"side": "against", "text": "Spaces ensure consistent rendering"},
+        ],
+    }, headers=_HOST_AUTH_HEADERS)
+
+    assert resp.status_code == 200
+    assert state.debate_phase == "prep"
+    assert state.debate_arguments[0]["text"] == "Tabs are better"
+    ai_args = [a for a in state.debate_arguments if a["ai_generated"]]
+    assert len(ai_args) == 1
+    assert ai_args[0]["side"] == "against"
+
+
+def test_debate_ai_result_rejects_wrong_phase():
+    """POST /api/debate/ai-result returns 400 if not in ai_cleanup phase."""
+    state.reset()
+    client = TestClient(app)
+    state.debate_statement = "Test"
+    state.debate_phase = "prep"
+
+    resp = client.post("/api/debate/ai-result", json={
+        "merges": [], "cleaned": [], "new_arguments": [],
+    }, headers=_HOST_AUTH_HEADERS)
+    assert resp.status_code == 400
+
+
+def test_debate_end_arguments_skips_ai_when_no_args():
+    """End arguments with no arguments should skip ai_cleanup, go to prep."""
+    state.reset()
+    client = TestClient(app)
+    client.post("/api/debate", json={"statement": "Test"}, headers=_HOST_AUTH_HEADERS)
+    state.debate_phase = "arguments"
+    state.debate_arguments = []
+
+    resp = client.post("/api/debate/end-arguments", headers=_HOST_AUTH_HEADERS)
+    assert resp.status_code == 200
+    assert state.debate_phase == "prep"
+    assert state.debate_ai_request is None


### PR DESCRIPTION
## Summary
- Removes Anthropic API calls from the Railway-deployed backend entirely
- Debate AI cleanup now runs through the local quiz daemon: backend exposes `GET /api/debate/ai-request` (poll) and `POST /api/debate/ai-result` (receive), daemon calls Claude locally and posts results back
- Adds loading spinner during `ai_cleanup` phase for both host and participants, plus a "Skip AI" button for the host if the daemon is unavailable
- Updates C2 container diagram to reflect the new architecture
- Adds 4 endpoint tests covering the poll/result flow, wrong-phase guard, and empty-arguments skip

## Test plan
- [x] All 98 tests pass
- [ ] Start daemon locally, launch debate, submit arguments, click "End Phase" — verify AI-generated arguments appear
- [ ] Verify spinner shows during ai_cleanup and disappears when prep arrives
- [ ] Verify "Skip AI" button advances to prep without AI enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)