### PR TITLE
SCRUM-1: Improve code review host line confirmation UX

### DIFF
--- a/static/host.css
+++ b/static/host.css
@@ -743,19 +743,26 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
     display: flex;
     padding: 2px 12px;
     transition: background 0.15s;
-    cursor: pointer;
+    cursor: default;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    margin: 1px 0;
 }
 
 .codereview-line-clickable {
     cursor: pointer;
 }
 
-.codereview-line:hover {
-    background: rgba(108,99,255,0.12) !important;
+.codereview-line-clickable:hover {
+    border-color: var(--accent);
 }
 
-.codereview-line-clickable:hover {
-    filter: brightness(1.2);
+.codereview-line-confirmed {
+    border-color: var(--accent2);
+}
+
+.codereview-line-selected {
+    border-color: var(--accent);
 }
 
 .codereview-gutter {

--- a/static/host.js
+++ b/static/host.js
@@ -1332,24 +1332,13 @@
       const isConfirmed = confirmed.has(lineNum);
       const isSelected = codereviewSelectedLine === lineNum;
 
-      let bgColor, borderColor, gutterText;
-      if (isConfirmed) {
-        bgColor = 'rgba(166,227,161,0.2)';
-        borderColor = 'var(--accent2)';
-        gutterText = `${lineNum} ✓`;
-      } else if (isSelected) {
-        bgColor = 'rgba(108,99,255,0.25)';
-        borderColor = 'var(--accent)';
-        gutterText = `${lineNum} ▶`;
-      } else {
-        bgColor = `rgba(108,99,255,${intensity * 0.5})`;
-        borderColor = 'transparent';
-        gutterText = String(lineNum);
-      }
-
+      // Background = participant heatmap only; border = host confirmation
+      const bgColor = `rgba(108,99,255,${intensity * 0.5})`;
+      const confirmedClass = isConfirmed ? 'codereview-line-confirmed' : '';
+      const selectedClass = isSelected ? 'codereview-line-selected' : '';
       const clickable = cr.phase === 'reviewing' && !isConfirmed ? 'codereview-line-clickable' : '';
-      html += `<div class="codereview-line ${clickable}" style="background:${bgColor};border-left:3px solid ${borderColor};" onclick="selectCodeReviewLine(${lineNum})">`;
-      html += `<span class="codereview-gutter">${gutterText}</span>`;
+      html += `<div class="codereview-line ${clickable} ${confirmedClass} ${selectedClass}" style="background:${bgColor};" onclick="selectCodeReviewLine(${lineNum})">`;
+      html += `<span class="codereview-gutter">${lineNum}</span>`;
       html += `<span class="codereview-code">${escHtml(lineText) || ' '}</span>`;
       if (count > 0) {
         const countColor = isConfirmed ? 'var(--accent2)' : 'var(--accent)';
@@ -1362,12 +1351,11 @@
   }
 
   function selectCodeReviewLine(lineNum) {
-    codereviewSelectedLine = lineNum;
     const lastState = window._lastCodereviewState;
-    if (lastState) {
-      renderHostCodePanel(lastState);
-      _updateCodeReviewLayout(lastState);
-    }
+    if (!lastState || lastState.phase !== 'reviewing') return; // no-op during selecting
+    codereviewSelectedLine = lineNum;
+    renderHostCodePanel(lastState);
+    _updateCodeReviewLayout(lastState);
   }
 
   function _updateCodeReviewLayout(cr) {
@@ -1421,8 +1409,9 @@
       html += '<div class="muted">No participants selected this line</div>';
     }
 
-    if (cr.phase === 'reviewing' && !isConfirmed && count > 0) {
-      html += `<button class="btn btn-success" style="width:100%;margin-top:12px;" onclick="confirmCodeReviewLine(${lineNum})">✓ Confirm Line (award 200 pts)</button>`;
+    if (cr.phase === 'reviewing' && !isConfirmed) {
+      const label = count > 0 ? '✓ Confirm Line (award 200 pts)' : '✓ Mark as problematic';
+      html += `<button class="btn btn-success" style="width:100%;margin-top:12px;" onclick="confirmCodeReviewLine(${lineNum})">${label}</button>`;
     }
     if (isConfirmed) {
       html += '<div style="text-align:center;margin-top:12px;color:var(--accent2);font-weight:600;">✓ Confirmed</div>';


### PR DESCRIPTION
## Summary
- Remove arrow (`▶`) indicator when host clicks a line — just show the line number
- Host can only select/confirm lines after voting closes (reviewing phase)
- Use border (not background) for confirmed/selected lines — preserves participant heatmap
- Host can mark ANY line as problematic, even with zero participant votes
- Contextual button label: "Confirm Line (award 200 pts)" vs "Mark as problematic"

Closes [SCRUM-1](https://victorrentea.atlassian.net/browse/SCRUM-1)

## Test plan
- [ ] Start a code review, verify clicking lines is a no-op during selecting phase
- [ ] Close voting, verify lines become clickable with hover border
- [ ] Click a line with 0 votes — should show "Mark as problematic" button
- [ ] Confirm it — green border appears, no background change
- [ ] Click a line with votes — should show "Confirm Line (award 200 pts)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)