### PR TITLE
feat: polish conference mode QR and badge layout

### DIFF
--- a/static/host.css
+++ b/static/host.css
@@ -812,6 +812,18 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
   justify-content: center;
   align-items: center;
 }
+/* Mode badge — white background for visibility */
+.mode-badge-workshop {
+  background: #fff !important;
+  color: #333 !important;
+  border: 2px solid var(--accent) !important;
+}
+.mode-badge-conference {
+  background: #fff !important;
+  color: #333 !important;
+  border: 2px solid #e74c3c !important;
+}
+
 /* Conference mode: bright white center QR */
 .conference-center-qr {
   background: #fff !important;

--- a/static/host.html
+++ b/static/host.html
@@ -180,6 +180,8 @@
 
     <!-- Status badges — pinned to bottom of left column -->
     <div class="left-status-bar">
+      <span id="mode-badge" class="badge mode-badge-workshop" title="Workshop mode — click to switch to Conference" onclick="toggleMode()" style="cursor:pointer; font-size:1.2rem;">🎓</span>
+      <span id="conference-pax-count" class="badge connected" style="display:none" title="Connected participants">👥 0</span>
       <span id="ws-badge" class="badge disconnected">🟢</span>
       <span id="daemon-badge" class="badge disconnected" title="">🤖</span>
       <span id="transcript-badge" class="badge disconnected" title="No transcription data">💬</span>
@@ -187,8 +189,6 @@
       <span id="summary-badge" class="badge disconnected" title="No key points yet — click to generate now" onclick="toggleSummaryModal()" style="cursor:pointer">🧠</span>
       <span id="overlay-badge" class="badge disconnected" title="Emoji overlay app">❤️</span>
       <span id="token-badge" class="badge" title="No token data yet">$0.00</span>
-      <span id="conference-pax-count" class="badge connected" style="display:none" title="Connected participants">👥 0</span>
-      <span id="mode-badge" class="badge connected" title="Workshop mode — click to switch to Conference" onclick="toggleMode()" style="cursor:pointer">🎓</span>
     </div>
   </div>
 

--- a/static/host.js
+++ b/static/host.js
@@ -353,7 +353,7 @@
     if (!badge) return;
     badge.textContent = mode === 'conference' ? '🎤' : '🎓';
     badge.title = mode === 'conference' ? 'Conference mode — click to switch to Workshop' : 'Workshop mode — click to switch to Conference';
-    badge.className = 'badge ' + (mode === 'conference' ? 'error' : 'connected');
+    badge.className = 'badge ' + (mode === 'conference' ? 'mode-badge-conference' : 'mode-badge-workshop');
     applyConferenceLayout(mode === 'conference');
   }
 


### PR DESCRIPTION
## Summary
- Center QR shown fullscreen bright white when idle in conference mode; left QR with wave URL animation and "N Joined" counter shown only when an activity is active
- Mode badge moved to first position in status bar with larger emoji and white background for visibility
- Token and notes badges hidden in conference mode

## Test plan
- [ ] Toggle conference mode on host panel — verify center QR is bright white and full-screen
- [ ] Start an activity — verify left QR appears with wave URL animation and joined count
- [ ] Verify mode badge is first in the badge list, larger, and clearly visible
- [ ] Verify token (💰) and notes (📝) badges are hidden in conference mode
- [ ] Switch back to workshop mode — verify original layout restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)