### PR TITLE
fix: prevent overlay WS reconnect race from dropping new connection

### DIFF
--- a/routers/ws.py
+++ b/routers/ws.py
@@ -352,7 +352,9 @@ async def websocket_endpoint(websocket: WebSocket, participant_id: str):
 
 
     except WebSocketDisconnect:
-        state.participants.pop(pid, None)
+        # Only remove if the stored WS is still ours (avoids race on reconnect-kick)
+        if state.participants.get(pid) is websocket:
+            state.participants.pop(pid, None)
         state.locations.pop(pid, None)
         state.vote_times.pop(pid, None)
         ws_connections_active.labels(role=role).dec()


### PR DESCRIPTION
## Summary
- When the overlay (or host) reconnects, the server kicks the old WebSocket. The old connection's disconnect handler was blindly removing the pid from `state.participants`, which now pointed to the **new** connection — killing it immediately.
- Fix: only pop the participant entry if the stored WebSocket is still the one that disconnected.
- This eliminates the infinite reconnect loop seen in EmojiOverlay logs.

## Test plan
- [ ] Deploy and verify EmojiOverlay connects and stays connected
- [ ] Test overlay reconnect by restarting the overlay app — new connection should survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)