### PR TITLE
feat: emoji on host, bigger mobile emoji, avatar enlarge+refresh

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -142,6 +142,10 @@
 - [x] In the code review for host, the title of code review doesn't stay on top of the code section; it stays somehow on top of the entire panel, which is asymmetric based on the compared with the line that delimits that take the code from the list of users. So center the code review title above the code div.
 - [x] In the poll view for the host, increase the name of the size of the font of the options and the question. Make it double and make sure that if the question is longer, it falls onto the second line cleanly.
 - [x] In the poll screen for a host, the slider color and text ("15 seconds default") should be in the same color as the button to close voting, to suggest it's closing the voting. As well as the text which gets displayed when you drag the slider. Also try to put the button to remove the question aligned to the right. Replace all the trash bins and all the other buttons with the same emoji that stays in front of the remove question label. I like it.
+- [x] Show emoji reactions on host browser page (floating animation like participant page) — currently only forwarded to native overlay app
+- [x] Make mobile emoji reactions bigger (~8rem) and longer (~1.8s) — currently 5rem / 0.8s
+- [x] Click avatar to enlarge: mobile = almost full screen (~90vh/90vw), desktop = large overlay; show refresh 🔄 icon in bottom-right of enlarged view to re-roll avatar
+- [x] Avatar refresh via WebSocket: `refresh_avatar` message reassigns avatar ensuring no duplicates among currently connected participants
  ---
 
 ## Understanding design

--- a/messaging.py
+++ b/messaging.py
@@ -432,3 +432,14 @@ async def send_emoji_to_overlay(emoji: str):
         await ws.send_text(json.dumps({"type": "emoji_reaction", "emoji": emoji}))
     except Exception:
         state.participants.pop("__overlay__", None)
+
+
+async def send_emoji_to_host(emoji: str):
+    """Forward an emoji reaction to the host client if connected."""
+    ws = state.participants.get("__host__")
+    if ws is None:
+        return
+    try:
+        await ws.send_text(json.dumps({"type": "emoji_reaction", "emoji": emoji}))
+    except Exception:
+        state.participants.pop("__host__", None)

--- a/routers/ws.py
+++ b/routers/ws.py
@@ -14,6 +14,7 @@ from messaging import (
     send_state_to_participant,
     send_state_to_host,
     send_emoji_to_overlay,
+    send_emoji_to_host,
 )
 from metrics import (
     ws_connections_active,
@@ -23,7 +24,7 @@ from metrics import (
     qa_questions_total,
     qa_upvotes_total,
 )
-from state import state, ActivityType, assign_avatar
+from state import state, ActivityType, assign_avatar, refresh_avatar
 from messaging import participant_ids
 from routers.debate import auto_assign_remaining
 
@@ -338,6 +339,12 @@ async def websocket_endpoint(websocket: WebSocket, participant_id: str):
                 emoji = str(data.get("emoji", "")).strip()
                 if emoji and len(emoji) <= 4:
                     await send_emoji_to_overlay(emoji)
+                    await send_emoji_to_host(emoji)
+
+            elif msg_type == "refresh_avatar":
+                new_avatar = refresh_avatar(state, pid)
+                if new_avatar:
+                    await broadcast_state()
 
             elif msg_type == "codereview_deselect":
                 line = data.get("line")

--- a/state.py
+++ b/state.py
@@ -135,3 +135,23 @@ def assign_avatar(app_state: AppState, uuid: str, name: str) -> str:
     avatar = get_avatar_filename(LOTR_NAMES[preferred_index])
     app_state.participant_avatars[uuid] = avatar
     return avatar
+
+
+def refresh_avatar(app_state: AppState, uuid: str) -> str | None:
+    """Reassign a random avatar different from current, ensuring uniqueness among connected participants."""
+    current = app_state.participant_avatars.get(uuid)
+    # Get avatars used by OTHER currently connected participants
+    connected_uuids = set(app_state.participants.keys()) - {"__host__", "__overlay__"}
+    taken = {app_state.participant_avatars[u] for u in connected_uuids
+             if u in app_state.participant_avatars and u != uuid}
+
+    available = [get_avatar_filename(n) for n in LOTR_NAMES
+                 if get_avatar_filename(n) not in taken and get_avatar_filename(n) != current]
+    if not available:
+        # All taken, at least pick something different from current
+        available = [get_avatar_filename(n) for n in LOTR_NAMES if get_avatar_filename(n) != current]
+    if not available:
+        return None
+    new_avatar = random.choice(available)
+    app_state.participant_avatars[uuid] = new_avatar
+    return new_avatar

--- a/static/host.css
+++ b/static/host.css
@@ -965,3 +965,17 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
   from { opacity: 0; transform: translateY(40px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* ── Floating emoji reactions ── */
+.host-emoji-float {
+  position: fixed;
+  bottom: 10%;
+  font-size: 2.5rem;
+  z-index: 10000;
+  pointer-events: none;
+  animation: host-emoji-rise 1.5s ease-out forwards;
+}
+@keyframes host-emoji-rise {
+  0%   { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-200px); }
+}

--- a/static/host.js
+++ b/static/host.js
@@ -257,8 +257,19 @@
         renderPreview(msg.quiz || null);
       } else if (msg.type === 'summary') {
         updateSummary(msg.points, msg.updated_at);
+      } else if (msg.type === 'emoji_reaction') {
+        showHostEmoji(msg.emoji);
       }
     };
+  }
+
+  function showHostEmoji(emoji) {
+    const el = document.createElement('div');
+    el.className = 'host-emoji-float';
+    el.textContent = emoji;
+    el.style.right = (5 + Math.random() * 20) + '%';
+    document.body.appendChild(el);
+    el.addEventListener('animationend', () => el.remove());
   }
 
   function escHtml(s) {

--- a/static/participant.css
+++ b/static/participant.css
@@ -754,7 +754,7 @@ h1 { display: none; }
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) scale(0.5);
-  font-size: 5rem;
+  font-size: 8rem;
   z-index: 10000;
   pointer-events: none;
   opacity: 0;
@@ -762,7 +762,7 @@ h1 { display: none; }
 }
 .emoji-shake-active {
   opacity: 1;
-  animation: emoji-shake .8s ease-out forwards;
+  animation: emoji-shake 1.4s ease-out forwards;
 }
 .emoji-shake-fade {
   opacity: 0;
@@ -859,4 +859,92 @@ h1 { display: none; }
 @keyframes lbFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
+}
+
+/* Avatar modal overlay */
+.avatar-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+  animation: avatar-modal-fade-in .2s ease-out;
+}
+
+@keyframes avatar-modal-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.avatar-modal-container {
+  position: relative;
+  display: inline-block;
+}
+
+.avatar-modal-img {
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 8px 32px rgba(0,0,0,.6);
+  border: 3px solid var(--accent);
+}
+
+.avatar-modal-letter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  font-weight: 800;
+  font-size: 6rem;
+  color: #fff;
+  box-shadow: 0 8px 32px rgba(0,0,0,.6);
+}
+
+.avatar-refresh-btn {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,.3);
+  background: rgba(0,0,0,.6);
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background .2s, transform .2s;
+}
+
+.avatar-refresh-btn:hover {
+  background: rgba(0,0,0,.8);
+  transform: scale(1.1);
+}
+
+/* Mobile: almost full screen avatar */
+@media (max-width: 600px) {
+  .avatar-modal-img {
+    width: 90vw;
+    height: 90vw;
+    max-height: 90vh;
+  }
+  .avatar-modal-letter {
+    width: 90vw;
+    height: 90vw;
+    max-height: 90vh;
+    font-size: 15rem;
+  }
+  .avatar-refresh-btn {
+    width: 56px;
+    height: 56px;
+    font-size: 1.6rem;
+    bottom: 5%;
+    right: 5%;
+  }
 }

--- a/static/participant.js
+++ b/static/participant.js
@@ -90,6 +90,69 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
     return `hsl(${hue}, 60%, 40%)`;
   }
 
+  function showAvatarModal(src) {
+    // Remove existing modal if any
+    const existing = document.getElementById('avatar-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'avatar-modal';
+    modal.className = 'avatar-modal-overlay';
+
+    const container = document.createElement('div');
+    container.className = 'avatar-modal-container';
+
+    const img = document.createElement('img');
+    img.src = src;
+    img.className = 'avatar-modal-img';
+
+    const refreshBtn = document.createElement('button');
+    refreshBtn.className = 'avatar-refresh-btn';
+    refreshBtn.innerHTML = '\u{1F504}';
+    refreshBtn.title = 'Get a new avatar';
+    refreshBtn.onclick = function(e) {
+        e.stopPropagation();
+        if (ws) ws.send(JSON.stringify({ type: 'refresh_avatar' }));
+        // Close modal - new avatar will appear on next state broadcast
+        modal.remove();
+    };
+
+    container.appendChild(img);
+    container.appendChild(refreshBtn);
+    modal.appendChild(container);
+
+    modal.addEventListener('click', function() { modal.remove(); });
+    container.addEventListener('click', function(e) { e.stopPropagation(); });
+
+    document.body.appendChild(modal);
+  }
+
+  function showLetterAvatarModal(letters, bgColor) {
+    const existing = document.getElementById('avatar-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'avatar-modal';
+    modal.className = 'avatar-modal-overlay';
+
+    const container = document.createElement('div');
+    container.className = 'avatar-modal-container';
+
+    const avatar = document.createElement('span');
+    avatar.className = 'avatar-modal-letter';
+    avatar.style.background = bgColor;
+    avatar.textContent = letters;
+
+    // No refresh button for letter avatars (conference mode)
+
+    container.appendChild(avatar);
+    modal.appendChild(container);
+
+    modal.addEventListener('click', function() { modal.remove(); });
+
+    document.body.appendChild(modal);
+  }
+
 
   let notesContent = '';
 
@@ -473,6 +536,15 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
                 existing.textContent = lt;
                 existing.style.display = '';
             }
+            // Also bind click-to-enlarge for letter avatars
+            const letterEl = document.getElementById('my-avatar');
+            if (letterEl && !letterEl._clickBound) {
+                letterEl._clickBound = true;
+                letterEl.style.cursor = 'pointer';
+                letterEl.addEventListener('click', function() {
+                    showLetterAvatarModal(this.textContent, this.style.background);
+                });
+            }
         } else if (msg.my_avatar) {
             const avatarEl = document.getElementById('my-avatar');
             avatarEl.src = '/static/avatars/' + msg.my_avatar;
@@ -484,27 +556,12 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
                 fallback.style.background = avatarColorFromUuid(window._myUuid);
                 this.replaceWith(fallback);
             };
-            // Hover preview: show 3x avatar near cursor
-            if (!avatarEl._hoverBound) {
-                avatarEl._hoverBound = true;
+            // Click to enlarge avatar + optional refresh
+            if (!avatarEl._clickBound) {
+                avatarEl._clickBound = true;
                 avatarEl.style.cursor = 'pointer';
-                let preview = null;
-                avatarEl.addEventListener('mouseenter', function(e) {
-                    preview = document.createElement('img');
-                    preview.className = 'avatar-preview';
-                    preview.src = this.src;
-                    preview.style.left = e.clientX + 'px';
-                    preview.style.top = e.clientY + 'px';
-                    document.body.appendChild(preview);
-                });
-                avatarEl.addEventListener('mousemove', function(e) {
-                    if (preview) {
-                        preview.style.left = e.clientX + 'px';
-                        preview.style.top = e.clientY + 'px';
-                    }
-                });
-                avatarEl.addEventListener('mouseleave', function() {
-                    if (preview) { preview.remove(); preview = null; }
+                avatarEl.addEventListener('click', function() {
+                    showAvatarModal(this.src);
                 });
             }
         }
@@ -1039,8 +1096,8 @@ let myWords = [];  // participant's own submitted words (persisted in localStora
     requestAnimationFrame(() => el.classList.add('emoji-shake-active'));
     setTimeout(() => {
       el.classList.add('emoji-shake-fade');
-      setTimeout(() => el.remove(), 400);
-    }, 800);
+      setTimeout(() => el.remove(), 600);
+    }, 1400);
   }
 
   function showDesktopEmojiFloat(emoji, btn) {


### PR DESCRIPTION
## Summary
- Forward emoji reactions to host browser page with floating rise animation (was overlay-only)
- Mobile emoji reactions: bigger (8rem vs 5rem) and longer (1.4s shake + 0.6s fade vs 0.8s + 0.4s)
- Click avatar to enlarge: almost full screen on mobile (~90vw), 300px on desktop
- Refresh icon (🔄) on enlarged avatar to re-roll — server ensures no duplicates among connected participants

## Test plan
- [ ] Open host page in browser, have participant send emoji → verify floating emoji appears in bottom-right
- [ ] Send emoji from mobile-width participant → verify larger size and longer animation
- [ ] Click avatar on mobile → verify almost-full-screen modal
- [ ] Click avatar on desktop → verify 300px modal with refresh button
- [ ] Click refresh button → verify avatar changes to a different one
- [ ] With 2+ participants, refresh avatar → verify no duplicate avatars assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)