### PR TITLE
feat: show QR code permanently in conference mode

### DIFF
--- a/docs/superpowers/specs/2026-03-22-conference-qr-always-visible-design.md
+++ b/docs/superpowers/specs/2026-03-22-conference-qr-always-visible-design.md
@@ -6,28 +6,39 @@ In conference mode, the `conference-qr` container (QR code + URL + participant c
 
 ## Design
 
-In conference mode, the left column (`host-col-left`) splits into a CSS grid with two equal rows:
+In conference mode, the left column (`host-col-left`) splits into a CSS grid with three rows:
 
-1. **Top half (1fr)**: Tab bar + tab content area with internal scroll (`overflow-y: auto`)
+1. **Top half (1fr)**: New wrapper div around tab bar + all tab content panels, with internal scroll
 2. **Bottom half (1fr)**: `conference-qr` container, always visible
+3. **Auto row**: `.left-status-bar` pinned at the bottom
+
+### HTML Changes (host.html)
+
+Add a wrapper `<div class="left-tabs-wrapper">` around the tab bar (`.tab-bar`) and all tab content panels (`#tab-content-poll` through `#tab-content-debate`). This gives the grid exactly two meaningful content rows plus the status bar.
 
 ### CSS Changes (host.css)
 
-Add a class or conference-mode rule for `.host-col-left`:
-- `display: grid; grid-template-rows: 1fr 1fr`
-- Tab content wrapper gets `overflow-y: auto; min-height: 0` to scroll within its half
-- `conference-qr` takes the bottom half with `display: flex` (already styled)
+Add conference-mode class `.conference-layout` on `.host-col-left`:
+- `display: grid; grid-template-rows: 1fr 1fr auto`
+- `.left-tabs-wrapper` gets `overflow-y: auto; min-height: 0` to scroll within its half
+- `conference-qr` takes the second row
+- `.left-status-bar` takes the auto row
 
 ### JS Changes (host.js)
 
-- `applyConferenceLayout(true)`: Set `conference-qr` to `display: flex` unconditionally (always visible)
-- `applyConferenceLayout(false)`: Set `conference-qr` to `display: none`
-- `updateCenterPanel`: Remove the conditional logic (lines ~1192-1196) that toggles `conference-qr` visibility based on activity state
+- `applyConferenceLayout(true)`: Add `conference-layout` class to `.host-col-left`; set `conference-qr` to `display: flex` unconditionally; hide `#conference-pax-display` (redundant — QR container already shows "N Joined")
+- `applyConferenceLayout(false)`: Remove `conference-layout` class; set `conference-qr` to `display: none`
+- `updateCenterPanel` function: Remove the conditional logic that toggles `conference-qr` visibility based on activity state
+
+### Elements addressed
+
+- `#conference-pax-display`: Hidden when QR is always visible (its "N connected" is redundant with QR's "N Joined" counter)
+- `.left-status-bar`: Placed in a third `auto`-sized grid row, stays pinned at bottom
+- `.conference-qr-container` `flex: 1`: Dead CSS in grid mode, can be cleaned up
 
 ### No Changes
 
 - QR code generation (already works: 200x200, black on white)
 - Animated URL display
-- Participant counter
 - Center and right column behavior
 - Workshop mode behavior

--- a/static/host.css
+++ b/static/host.css
@@ -820,10 +820,19 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
   display: none;
   text-align: center;
   padding: 1rem 0;
-  flex: 1;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+/* Conference mode: left column splits into tabs (top) + QR (bottom) + status bar */
+.host-col-left.conference-layout {
+  display: grid;
+  grid-template-rows: 1fr 1fr auto;
+}
+.host-col-left.conference-layout .left-tabs-wrapper {
+  overflow-y: auto;
+  min-height: 0;
 }
 /* Mode badge — white background for visibility */
 .mode-badge-workshop {

--- a/static/host.html
+++ b/static/host.html
@@ -19,6 +19,7 @@
 
   <!-- LEFT COLUMN: controls -->
   <div class="host-col host-col-left">
+    <div class="left-tabs-wrapper">
     <!-- Tab switcher -->
     <div class="tab-bar">
       <button class="tab-btn active" id="tab-poll" onclick="switchTab('poll')"><span class="tab-icon">📊</span>Poll</button>
@@ -140,8 +141,9 @@
         <button class="btn btn-danger btn-sm" onclick="debateReset()">🗑️ Reset Debate</button>
       </div>
     </div>
+    </div><!-- /left-tabs-wrapper -->
 
-    <!-- Conference mode: QR code shown in left column (only when activity is active) -->
+    <!-- Conference mode: QR code shown in left column -->
     <div id="conference-qr" class="conference-qr-container">
       <div id="conference-qr-code" style="background:#fff; padding:12px; border-radius:12px; display:inline-block;"></div>
       <div id="conference-qr-url" style="margin-top:.5rem; font-size:.85rem;"></div>

--- a/static/host.js
+++ b/static/host.js
@@ -392,12 +392,14 @@
     // Detect light/dark mode for QR color adaptation
     const isLight = window.matchMedia('(prefers-color-scheme: light)').matches;
 
+    const leftCol = document.querySelector('.host-col-left');
     if (isConference) {
       rightCol.style.display = 'none';
       grid.style.gridTemplateColumns = '25% 1fr';
-      // Left QR hidden by default — shown only when an activity is active (see updateCenterPanel)
-      confQR.style.display = 'none';
-      if (confPaxDisplay) confPaxDisplay.style.display = '';
+      leftCol.classList.add('conference-layout');
+      // QR always visible in conference mode
+      confQR.style.display = 'flex';
+      if (confPaxDisplay) confPaxDisplay.style.display = 'none';
       if (debateTab) debateTab.style.display = 'none';
       if (tokenCost) tokenCost.style.display = 'none';
       if (notesBadge) notesBadge.style.display = 'none';
@@ -429,6 +431,7 @@
     } else {
       rightCol.style.display = '';
       grid.style.gridTemplateColumns = '25% 1fr 25%';
+      leftCol.classList.remove('conference-layout');
       confQR.style.display = 'none';
       if (confPaxDisplay) confPaxDisplay.style.display = 'none';
       if (debateTab) debateTab.style.display = '';
@@ -1188,13 +1191,6 @@
         document.getElementById('tab-' + t).classList.toggle('active', currentActivity === t);
         document.getElementById('tab-content-' + t).style.display = currentActivity === t ? (t === 'codereview' ? 'flex' : '') : 'none';
       });
-    }
-    // Conference mode: show left QR only when an activity is active (center QR hidden)
-    if (currentMode === 'conference') {
-      const confQR = document.getElementById('conference-qr');
-      if (confQR) {
-        confQR.style.display = (currentActivity && currentActivity !== 'none') ? 'flex' : 'none';
-      }
     }
   }
 

--- a/static/work-hours.js
+++ b/static/work-hours.js
@@ -1,1 +1,1 @@
-window.WORK_HOURS = 40;
+window.WORK_HOURS = 41;


### PR DESCRIPTION
## Summary
- In conference mode, the left panel now uses a CSS grid layout (50/50 split)
- QR code for joining is always visible in the bottom half of the left panel
- Tab content (polls, Q&A, code review, etc.) scrolls within the top half
- Removed conditional QR toggle that only showed it during active activities

## Test plan
- [ ] Open host panel, switch to conference mode — QR visible in bottom-left
- [ ] Start various activities (poll, code review, word cloud) — QR stays visible
- [ ] Switch back to workshop mode — QR hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)