### PR TITLE
fix: code review textarea fills top half in conference mode

### DIFF
--- a/static/host.css
+++ b/static/host.css
@@ -819,20 +819,34 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
 .conference-qr-container {
   display: none;
   text-align: center;
-  padding: 1rem 0;
+  padding: .5rem 0;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
+}
+.conference-qr-container #conference-qr-code {
+  padding: 6px;
+}
+.conference-qr-container #conference-qr-code img,
+.conference-qr-container #conference-qr-code canvas {
+  width: 120px !important;
+  height: 120px !important;
 }
 
 /* Conference mode: left column splits into tabs (top) + QR (bottom) + status bar */
 .host-col-left.conference-layout {
   display: grid;
-  grid-template-rows: 1fr 1fr auto;
+  grid-template-rows: 1fr auto auto;
 }
 .host-col-left.conference-layout .left-tabs-wrapper {
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   min-height: 0;
+}
+.host-col-left.conference-layout .tab-content {
+  overflow-y: auto;
 }
 /* Mode badge — white background for visibility */
 .mode-badge-workshop {


### PR DESCRIPTION
## Summary
- Left-tabs-wrapper is now a flex column so tab content stretches to fill available space
- Grid changed from 1fr/1fr to 1fr/auto so tabs get priority over QR
- Left-panel QR shrunk to 120px for more tab content room

## Test plan
- [ ] Conference mode + Code Review tab: textarea fills top section
- [ ] Other tabs (Poll, Q&A, Words) scroll properly in top section
- [ ] Workshop mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)