### PR TITLE
feat: single-instance enforcement for emoji-overlay via PID lock

### DIFF
--- a/emoji-overlay/Sources/EmojiOverlay/AppDelegate.swift
+++ b/emoji-overlay/Sources/EmojiOverlay/AppDelegate.swift
@@ -8,9 +8,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, URLSessionWebSocketDelegate 
     private var wsTask: URLSessionWebSocketTask?
     private var session: URLSession!
     private var reconnecting = false
+    private let pidFilePath: String
+    private let myPID: Int32
+    private var pidCheckTimer: Timer?
 
-    init(serverURL: String) {
+    init(serverURL: String, pidFilePath: String, myPID: Int32) {
         self.serverURL = serverURL
+        self.pidFilePath = pidFilePath
+        self.myPID = myPID
         super.init()
     }
 
@@ -25,6 +30,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, URLSessionWebSocketDelegate 
 
         session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
         connectWebSocket()
+
+        // Check every 2s if another instance took over the PID file
+        pidCheckTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            self?.checkPIDFile()
+        }
+    }
+
+    private func checkPIDFile() {
+        guard let content = try? String(contentsOfFile: pidFilePath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+              let filePID = Int32(content) else {
+            return
+        }
+        if filePID != myPID {
+            NSLog("Another instance (PID \(filePID)) took over — shutting down (my PID: \(myPID))")
+            pidCheckTimer?.invalidate()
+            wsTask?.cancel(with: .goingAway, reason: nil)
+            NSApplication.shared.terminate(nil)
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/emoji-overlay/Sources/EmojiOverlay/main.swift
+++ b/emoji-overlay/Sources/EmojiOverlay/main.swift
@@ -1,7 +1,14 @@
 import AppKit
+import Foundation
 
 let app = NSApplication.shared
 app.setActivationPolicy(.regular)
+
+// Write PID lock file — newest instance always wins
+let pidFilePath = "/tmp/emoji-overlay.pid"
+let myPID = ProcessInfo.processInfo.processIdentifier
+try? "\(myPID)".write(toFile: pidFilePath, atomically: true, encoding: .utf8)
+NSLog("Started with PID \(myPID), wrote lock file")
 
 // Server URL from command line or default
 let serverURL: String
@@ -11,6 +18,6 @@ if CommandLine.arguments.count > 1 {
     serverURL = "ws://localhost:8000"
 }
 
-let delegate = AppDelegate(serverURL: serverURL)
+let delegate = AppDelegate(serverURL: serverURL, pidFilePath: pidFilePath, myPID: myPID)
 app.delegate = delegate
 app.run()


### PR DESCRIPTION
## Summary
- New instance writes its PID to `/tmp/emoji-overlay.pid` on startup, always overwriting
- Running instance checks the PID file every 2s and auto-terminates if another instance has taken over
- Ensures only one emoji-overlay process runs at a time, with the newest instance winning

🤖 Generated with [Claude Code](https://claude.com/claude-code)