### PR TITLE
fix: conference QR - hide left when center visible, black bg

### DIFF
--- a/static/host.css
+++ b/static/host.css
@@ -826,12 +826,14 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
   overflow: hidden;
 }
 .conference-qr-container #conference-qr-code {
-  padding: 6px;
+  padding: 8px;
 }
 .conference-qr-container #conference-qr-code img,
 .conference-qr-container #conference-qr-code canvas {
-  width: 120px !important;
-  height: 120px !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: 180px;
+  max-height: 180px;
 }
 
 /* Conference mode: left column splits into tabs (top) + QR (bottom) + status bar */
@@ -860,17 +862,16 @@ textarea { resize: none; min-height: 80px; overflow: hidden; }
   border: 2px solid #e74c3c !important;
 }
 
-/* Conference mode: bright center QR — adapts to color scheme */
+/* Conference mode: center QR — black background with white-bordered QR */
 .conference-center-qr {
-  background: #fff !important;
+  background: #000 !important;
 }
 .conference-center-qr .qr-code {
   opacity: 1 !important;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
 }
-@media (prefers-color-scheme: light) {
-  .conference-center-qr {
-    background: var(--bg) !important;
-  }
 
 /* Leaderboard button */
 .leaderboard-btn {

--- a/static/host.js
+++ b/static/host.js
@@ -440,8 +440,9 @@
       rightCol.style.display = 'none';
       grid.style.gridTemplateColumns = '25% 1fr';
       leftCol.classList.add('conference-layout');
-      // QR always visible in conference mode
-      confQR.style.display = 'flex';
+      // Show left QR only when an activity is active (center QR not visible)
+      const centerQRVisible = document.getElementById('center-qr').style.display !== 'none';
+      confQR.style.display = centerQRVisible ? 'none' : 'flex';
       if (confPaxDisplay) confPaxDisplay.style.display = 'none';
       if (debateTab) debateTab.style.display = 'none';
       if (tokenCost) tokenCost.style.display = 'none';
@@ -1229,6 +1230,12 @@
         el.style.display = currentActivity === id ? showVal : 'none';
       }
     });
+    // In conference mode: hide left QR when center QR is visible (no activity)
+    const leftCol = document.querySelector('.host-col-left');
+    if (leftCol && leftCol.classList.contains('conference-layout')) {
+      const confQR = document.getElementById('conference-qr');
+      confQR.style.display = currentActivity === 'none' ? 'none' : 'flex';
+    }
     if (currentActivity && currentActivity !== 'none') {
       ['poll', 'wordcloud', 'qa', 'codereview', 'debate'].forEach(t => {
         document.getElementById('tab-' + t).classList.toggle('active', currentActivity === t);


### PR DESCRIPTION
## Summary
- Hide left QR when center QR is showing (no active activity)
- Show left QR only when an activity occupies the center panel
- Center QR in conference mode: black background with white-bordered QR
- Left QR scales to fill available width

## Test plan
- [ ] Conference mode idle: center QR on black bg, no left QR
- [ ] Conference mode + activity: left QR appears, center shows activity
- [ ] Workshop mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)