### PR TITLE
feat: show daemon connection status on host landing page

### DIFF
--- a/static/host.html
+++ b/static/host.html
@@ -243,7 +243,13 @@
     </div>
     <!-- Poll results panel -->
     <div id="center-poll" class="center-panel" style="display:none;">
-      <div style="flex-shrink:0;">
+      <!-- Daemon status shown on landing (activity=none) -->
+      <div id="daemon-landing-status" style="display:none; flex-direction:column; align-items:center; justify-content:center; gap:.6rem; padding:2rem 1rem; text-align:center;">
+        <div id="daemon-landing-icon" style="font-size:3rem; line-height:1;">🤖</div>
+        <div id="daemon-landing-label" style="font-size:1.1rem; font-weight:600; color:var(--text);"></div>
+        <div id="daemon-landing-detail" style="font-size:.85rem; color:var(--muted); font-family:monospace;"></div>
+      </div>
+      <div id="poll-results-section" style="flex-shrink:0;">
         <div style="display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin-bottom:.9rem;">
           <h2 style="margin:0; font-size:.95rem; color:var(--muted); text-transform:uppercase; letter-spacing:.08em;">Current Poll</h2>
           <span id="poll-pills"></span>

--- a/static/host.js
+++ b/static/host.js
@@ -1093,12 +1093,15 @@
 
   function renderDaemonStatus(connected, lastSeenIso) {
     const el = document.getElementById('daemon-badge');
-    if (!el) return;
+    const landingIcon = document.getElementById('daemon-landing-icon');
+    const landingLabel = document.getElementById('daemon-landing-label');
+    const landingDetail = document.getElementById('daemon-landing-detail');
 
     if (!lastSeenIso) {
-      el.textContent = '🤖';
-      el.className = 'badge disconnected';
-      el.title = 'Never connected — start with ./start.sh';
+      if (el) { el.textContent = '🤖'; el.className = 'badge disconnected'; el.title = 'Never connected — start with ./start.sh'; }
+      if (landingIcon) landingIcon.style.opacity = '.35';
+      if (landingLabel) { landingLabel.textContent = 'Daemon not running'; landingLabel.style.color = 'var(--muted)'; }
+      if (landingDetail) landingDetail.textContent = './start.sh';
       return;
     }
 
@@ -1106,15 +1109,15 @@
     const agoText = ago < 60 ? `${ago}s ago` : `${Math.round(ago/60)}m ago`;
 
     if (connected) {
-      el.textContent = '🤖';
-      el.className = 'badge connected';
-      el.style.cssText = '';
-      el.title = `Connected (last seen ${agoText})`;
+      if (el) { el.textContent = '🤖'; el.className = 'badge connected'; el.style.cssText = ''; el.title = `Connected (last seen ${agoText})`; }
+      if (landingIcon) landingIcon.style.opacity = '1';
+      if (landingLabel) { landingLabel.textContent = 'Daemon connected'; landingLabel.style.color = 'var(--accent2)'; }
+      if (landingDetail) landingDetail.textContent = `last seen ${agoText}`;
     } else {
-      el.textContent = '🤖';
-      el.className = 'badge';
-      el.style.cssText = 'color:var(--warn);border:1px solid var(--warn);';
-      el.title = `Connection lost (last seen ${agoText})`;
+      if (el) { el.textContent = '🤖'; el.className = 'badge'; el.style.cssText = 'color:var(--warn);border:1px solid var(--warn);'; el.title = `Connection lost (last seen ${agoText})`; }
+      if (landingIcon) landingIcon.style.opacity = '.6';
+      if (landingLabel) { landingLabel.textContent = 'Daemon disconnected'; landingLabel.style.color = 'var(--warn)'; }
+      if (landingDetail) landingDetail.textContent = `last seen ${agoText}`;
     }
   }
 
@@ -2030,8 +2033,10 @@
         const show = currentActivity === 'poll' || currentActivity === 'none';
         el.style.display = show ? 'flex' : 'none';
         // Hide the poll results section when no poll is active
-        const pollResults = el.querySelector(':scope > div:first-child');
+        const pollResults = document.getElementById('poll-results-section');
         if (pollResults) pollResults.style.display = currentActivity === 'poll' ? '' : 'none';
+        const daemonLanding = document.getElementById('daemon-landing-status');
+        if (daemonLanding) daemonLanding.style.display = currentActivity === 'none' ? 'flex' : 'none';
         // Change divider text based on whether a poll exists
         const divider = el.querySelector('.or-divider span');
         if (divider) divider.textContent = currentActivity === 'poll' ? 'generate next' : 'generate question';


### PR DESCRIPTION
When activity is 'none', the center panel now displays the daemon status prominently (🤖 icon + label + last-seen detail) instead of an empty area.